### PR TITLE
Add codegen script

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@predy/fee-subgraph",
   "license": "UNLICENSED",
   "scripts": {
-    "codegen": "graph codegen",
+    "codegen": "bash ./scripts/codegen.sh",
     "test": "graph test",
     "build": "graph build",
     "fmt:fix": "prettier --write src/**/*",

--- a/scripts/codegen.sh
+++ b/scripts/codegen.sh
@@ -11,10 +11,10 @@ do
   if [ $counter -eq 0 ]; then
     mkdir generated/UniswapV3Pool
     mkdir generated/GammaShortStrategy
-    for file in $(ls ${dir})
+    for file in $(ls $dir)
     do
-      cp ${dir}${file} generated/UniswapV3Pool/
-      cp ${dir}${file} generated/GammaShortStrategy/
+      cp $dir$file generated/UniswapV3Pool/
+      cp $dir$file generated/GammaShortStrategy/
     done
   fi
   rm -rf $dir

--- a/scripts/codegen.sh
+++ b/scripts/codegen.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# generate code
+rm -rf generated
+graph codegen
+
+# copy generated code to suitable folders
+counter=0
+for dir in $(ls -d generated/*/)
+do
+  if [ $counter -eq 0 ]; then
+    mkdir generated/UniswapV3Pool
+    mkdir generated/GammaShortStrategy
+    for file in $(ls ${dir})
+    do
+      cp ${dir}${file} generated/UniswapV3Pool/
+      cp ${dir}${file} generated/GammaShortStrategy/
+    done
+  fi
+  rm -rf $dir
+  ((counter++))
+done


### PR DESCRIPTION
Currently, `graph codegen` generates many pool directories under `generated`. However, there is no need to use them. This PR allows you to run shellscript via `npm run codegen', which will generate typescript files, then copy typescript files to appropriate directories, and finally remove unused directories.